### PR TITLE
fix compatibility with tailwind v2

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,12 +12,13 @@ const getHalfValue = function(value) {
 };
 
 module.exports = plugin.withOptions(function(options = {}) {
-  return function({ theme, variants, target, addComponents, e }) {
+  return function({ theme, variants, target, addComponents, e, config }) {
     options = _.defaults({}, options, defaultOptions);
 
     const gapTheme = theme('gap');
     const gapVariants = variants('gap');
-    const ie11 = target('gap') === 'ie11'
+    // The `target` feature has been removed in Tailwind CSS v2.0
+    const ie11 = typeof target === 'function' ? target('gap') === 'ie11' : config('target') === 'ie11';
 
     if (!ie11) {
       addComponents({


### PR DESCRIPTION
The changes are tested to have #12 fixed.

However, Tailwind CSS v2 will still complain:
```
warn - The `target` feature has been removed in Tailwind CSS v2.0.
warn - Please remove this option from your config file to silence this warning.
```

This is because according to https://github.com/tailwindlabs/tailwindcss/pull/2571, Tailwind CSS v2.0 no longer supports IE11. I suggest bumping the package's version and claim that the new version should only be used with Tailwind CSS v2.0, dropping the support for IE11.

Or...merge the changes, keeping the support for IE11? 

